### PR TITLE
Allow callback style setState

### DIFF
--- a/src/unstated.js
+++ b/src/unstated.js
@@ -13,11 +13,20 @@ export class Container<State: {}> {
     this._listeners = [];
   }
 
-  setState(state: $Shape<State> | (State => $Shape<State>)) {
-    this.state =
-      typeof state === 'function'
-        ? state(this.state)
-        : Object.assign({}, this.state, state);
+  setState(state: $Shape<State> | (State => $Shape<State>)): void {
+    const prevState = this.state;
+    const newState = typeof state === 'function' ? state(prevState) : state;
+
+    /**
+     * allow either early return or ternary return of previous state to
+     * propagate correctly through component tree by not calling _listeners
+     * and leaving old state in place.
+     */
+    if (newState == null || newState === prevState) {
+      this.state = prevState;
+      return;
+    }
+    this.state = Object.assign({}, prevState, newState);
     this._listeners.forEach(fn => fn());
   }
 

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -13,8 +13,11 @@ export class Container<State: {}> {
     this._listeners = [];
   }
 
-  setState(state: $Shape<State>) {
-    this.state = Object.assign({}, this.state, state);
+  setState(state: $Shape<State> | (State => $Shape<State>)) {
+    this.state =
+      typeof state === 'function'
+        ? state(this.state)
+        : Object.assign({}, this.state, state);
     this._listeners.forEach(fn => fn());
   }
 


### PR DESCRIPTION
This PR allows the "callback" style `setState`, which React also allows. Where React allows it for asynchronicity, the change here would allow advanced users who are aware of (im)mutability concerns (which you take care of with Object.assign, to a certain extent) to make all state changes with a single pass of `lodash.flow` or `R.evolve`:

```js
import { flow, update, set, add } from 'lodash/fp';

class MyState extends Container {
  increment() {
    this.setState(flow(
      update(['nested', 'counter'], add(1)),
      set(['didIncrement'], true)
    ));
  }
}
```

"Advanced" (imagine airquotes, thanks :) ).
```js
import { flow, update, set, add, subtract, multiply } from 'lodash/fp';

class MyState extends Container {
  constructor() {
    super();

    this.increment = this.createSetState(add, 1);
    this.decrement = this.createSetState(substract, 1);
    this.double = this.createSetState(multiply, 2);
  }

  createSetState(method, count) {
    return () => this.setState(flow(
      update(['nested', 'counter'], method(count))
    ));
  }
}
```

### Todo

- [x] decide on Object.assign when using callback style
- [ ] add tests
- [ ] write documentation
- [ ] bump versions, publish etc.
