### PR TITLE
Add a `force` to `setState` to force the new state

### DIFF
--- a/src/unstated.js
+++ b/src/unstated.js
@@ -13,8 +13,8 @@ export class Container<State: {}> {
     this._listeners = [];
   }
 
-  setState(state: $Shape<State>) {
-    this.state = Object.assign({}, this.state, state);
+  setState(state: $Shape<State>, force) {
+    this.state = force ? state : Object.assign({}, this.state, state);
     this._listeners.forEach(fn => fn());
   }
 

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -13,7 +13,7 @@ export class Container<State: {}> {
     this._listeners = [];
   }
 
-  setState(state: $Shape<State>, force: Boolean) {
+  setState(state: $Shape<State>, force?: Boolean) {
     this.state = force ? state : Object.assign({}, this.state, state);
     this._listeners.forEach(fn => fn());
   }

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -13,7 +13,7 @@ export class Container<State: {}> {
     this._listeners = [];
   }
 
-  setState(state: $Shape<State>, force) {
+  setState(state: $Shape<State>, force: Boolean) {
     this.state = force ? state : Object.assign({}, this.state, state);
     this._listeners.forEach(fn => fn());
   }


### PR DESCRIPTION
When the state itself is a hash and you want to drop an element from that hash, `setState` always merges the element back.

Assuming `state = {}` which has been filled with various elements keyed by `id`
```
  deleteElement(id) {
      const { [id]: deleted, ...rest } = this.state;
      this.setState(rest, true);
  }
```
The added argument to `setState` forces `rest` to become the new state, instead of getting the deleted element merged back in.