### PR TITLE
[WIP] Make `to` in `<Subscribe>` support `Container` instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Next we'll need a piece to introduce our state back into the tree so that:
 * We can call methods on our container.
 
 For this we have the `<Subscribe>` component which allows us to pass our
-container classes and receive instances of them in the tree.
+container classes/instances and receive instances of them in the tree.
 
 ```js
 function Counter() {
@@ -376,4 +376,4 @@ paradigm on the entire universe.
 Unstated isn't ambitious, use it as you need it, it's nice and small for
 that reason. Don't think of it as a "Redux killer". Don't go trying to
 build complex tools on top of it. Don't reinvent the wheel. Just try it
-out and see how you like it. 
+out and see how you like it.

--- a/__tests__/unstated.tsx
+++ b/__tests__/unstated.tsx
@@ -69,6 +69,25 @@ function CounterWithAmountApp() {
   );
 }
 
+const sharedAmountContainer = new AmountContainer();
+function CounterWithSharedAmountApp() {
+    <Subscribe to={[sharedAmountContainer]}>
+      {(amounter: AmounterContainer) => (
+        <div>
+          <Counter />
+          <input
+            type="number"
+            value={amounter.state.amount}
+            onChange={event => {
+              amounter.setAmount(parseInt(event.currentTarget.value, 10));
+            }}
+          />
+        </div>
+      )}
+    </Subscribe>
+  );
+}
+
 let counter = new CounterContainer();
 let render = () => (
   <Provider inject={[counter]}>

--- a/__tests__/unstated.tsx
+++ b/__tests__/unstated.tsx
@@ -70,7 +70,9 @@ function CounterWithAmountApp() {
 }
 
 const sharedAmountContainer = new AmountContainer();
+
 function CounterWithSharedAmountApp() {
+  return (
     <Subscribe to={[sharedAmountContainer]}>
       {(amounter: AmounterContainer) => (
         <div>

--- a/example/index.html
+++ b/example/index.html
@@ -12,5 +12,9 @@
     <h3>Complex</h3>
     <div id="complex"></div>
     <script type="text/javascript" src="./complex.js"></script>
+
+    <h3>Shared</h3>
+    <div id="shared"></div>
+    <script type="text/javascript" src="./shared.js"></script>
   </body>
 </html>

--- a/example/shared.js
+++ b/example/shared.js
@@ -1,0 +1,43 @@
+// @flow
+import React from 'react';
+import { render } from 'react-dom';
+import { Provider, Subscribe, Container } from '../src/unstated';
+
+type CounterState = {
+  count: number
+};
+
+class CounterContainer extends Container<CounterState> {
+  state = { count: 0 };
+
+  increment() {
+    this.setState({ count: this.state.count + 1 });
+  }
+
+  decrement() {
+    this.setState({ count: this.state.count - 1 });
+  }
+}
+
+const sharedCounterContainer = new CounterContainer();
+
+function Counter() {
+  return (
+    <Subscribe to={[sharedCounterContainer]}>
+      {counter => (
+        <div>
+          <button onClick={() => counter.decrement()}>-</button>
+          <span>{counter.state.count}</span>
+          <button onClick={() => sharedCounterContainer.increment()}>+</button>
+        </div>
+      )}
+    </Subscribe>
+  );
+}
+
+render(
+  <Provider>
+    <Counter />
+  </Provider>,
+  window.shared
+);

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -91,11 +91,6 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
         ContainerItem instanceof Container
       ) {
         instance = ContainerItem;
-
-        let Class = instance.constructor;
-        if (!safeMap.has(Class)) {
-          safeMap.set(Class, instance);
-        }
       } else {
         instance = safeMap.get(ContainerItem);
 

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -84,7 +84,7 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
 
     let safeMap = map;
     let instances = containers.map(ContainerItem => {
-      let instance: ContainerType;
+      let instance;
 
       if (
         typeof ContainerItem === 'object' &&
@@ -97,7 +97,7 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
           safeMap.set(Class, instance);
         }
       } else {
-        instance = (safeMap.get(ContainerItem): any);
+        instance = safeMap.get(ContainerItem);
 
         if (!instance) {
           instance = new ContainerItem();

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -28,12 +28,14 @@ export class Container<State: {}> {
 }
 
 export type ContainerType = Container<Object>;
-export type ContainersType = Array<Class<ContainerType>>;
+export type ContainersType = Array<Class<ContainerType> | ContainerType>;
 export type ContainerMapType = Map<Class<ContainerType>, ContainerType>;
 
 export type SubscribeProps<Containers: ContainersType> = {
   to: Containers,
-  children: (...instances: $TupleMap<Containers, <C>(Class<C>) => C>) => Node
+  children: (
+    ...instances: $TupleMap<Containers, <C>(Class<C> | C) => C>
+  ) => Node
 };
 
 type SubscribeState = {};
@@ -81,12 +83,26 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
     }
 
     let safeMap = map;
-    let instances = containers.map(Container => {
-      let instance = safeMap.get(Container);
+    let instances = containers.map(ContainerItem => {
+      let instance: ContainerType;
 
-      if (!instance) {
-        instance = new Container();
-        safeMap.set(Container, instance);
+      if (
+        typeof ContainerItem === 'object' &&
+        ContainerItem instanceof Container
+      ) {
+        instance = ContainerItem;
+
+        let Class = instance.constructor;
+        if (!safeMap.has(Class)) {
+          safeMap.set(Class, instance);
+        }
+      } else {
+        instance = (safeMap.get(ContainerItem): any);
+
+        if (!instance) {
+          instance = new ContainerItem();
+          safeMap.set(ContainerItem, instance);
+        }
       }
 
       instance.unsubscribe(this.onUpdate);


### PR DESCRIPTION
For convenience when having containers that are always shared, like a global app container.

- [ ] Add docs