### PR TITLE
With subscription

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -12,5 +12,9 @@
     <h3>Complex</h3>
     <div id="complex"></div>
     <script type="text/javascript" src="./complex.js"></script>
+
+    <h3>withSubscription</h3>
+    <div id="withSubscription"></div>
+    <script type="text/javascript" src="./withSubscription.js"></script>
   </body>
 </html>

--- a/example/withSubscription.js
+++ b/example/withSubscription.js
@@ -1,0 +1,42 @@
+// @flow
+import React from 'react';
+import { render } from 'react-dom';
+import {
+  Provider,
+  Subscribe,
+  Container,
+  withSubscription
+} from '../src/unstated';
+
+type CounterState = {
+  count: number
+};
+
+class CounterContainer extends Container<CounterState> {
+  state = { count: 0 };
+
+  increment() {
+    this.setState({ count: this.state.count + 1 });
+  }
+
+  decrement() {
+    this.setState({ count: this.state.count - 1 });
+  }
+}
+
+const Counter = withSubscription({ counter: CounterContainer })(
+  ({ counter }) => (
+    <div>
+      <button onClick={() => counter.decrement()}>-</button>
+      <span>{counter.state.count}</span>
+      <button onClick={() => counter.increment()}>+</button>
+    </div>
+  )
+);
+
+render(
+  <Provider>
+    <Counter />
+  </Provider>,
+  window.withSubscription
+);

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { type Node } from 'react';
+import React, { type ComponentType, type Node } from 'react';
 import createReactContext from 'create-react-context';
 import PropTypes from 'prop-types';
 
@@ -139,3 +139,31 @@ export function Provider(props: ProviderProps) {
     </StateContext.Consumer>
   );
 }
+
+type ContainersMap = {
+  [string]: typeof Container
+};
+
+export const withSubscription = (containersMap: ContainersMap) => (
+  WrappedComponent: ComponentType<*>
+) => (props: *) => {
+  const containerKeys = Object.keys(containersMap);
+  const containers = containerKeys.map(
+    containerKey => containersMap[containerKey]
+  );
+
+  return (
+    <Subscribe to={containers}>
+      {(...containerInstances) => {
+        const containerProps = containerInstances.reduce(
+          (accumulator, instance, index) => ({
+            ...accumulator,
+            [containerKeys[index]]: instance
+          }),
+          {}
+        );
+        return <WrappedComponent {...props} {...containerProps} />;
+      }}
+    </Subscribe>
+  );
+};

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -141,7 +141,7 @@ export function Provider(props: ProviderProps) {
 }
 
 type ContainersMap = {
-  [string]: typeof Container
+  [string]: *
 };
 
 export const withSubscription = (containersMap: ContainersMap) => (

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -156,10 +156,10 @@ export const withSubscription = (containersMap: ContainersMap) => (
     <Subscribe to={containers}>
       {(...containerInstances) => {
         const containerProps = containerInstances.reduce(
-          (accumulator, instance, index) => ({
-            ...accumulator,
-            [containerKeys[index]]: instance
-          }),
+          (accumulator, instance, index) =>
+            Object.assign({}, accumulator, {
+              [containerKeys[index]]: instance
+            }),
           {}
         );
         return <WrappedComponent {...props} {...containerProps} />;


### PR DESCRIPTION
Hey dude, Jed and I were playing with this on Friday and we found that the 'function as children' pattern lead to us doing lots of logic in the render method, which was messy. It also felt messy having to pass a state container all over the place if we wanted to break the rendering down into separate functions.

This HOC allows you to map containers to props which means that state is accessible anywhere in your component, not just in the render.