### PR TITLE
Added `connect` HoC, similar to that in react-redux

### DIFF
--- a/example/connect.js
+++ b/example/connect.js
@@ -1,0 +1,87 @@
+// @flow
+import React from 'react';
+import { render } from 'react-dom';
+import { Provider, Subscribe, Container, connect } from '../src/unstated';
+
+type AppState = {
+  amount: number
+};
+
+class AppContainer extends Container<AppState> {
+  state = {
+    amount: 1
+  };
+
+  setAmount(amount: number) {
+    this.setState({ amount });
+  }
+}
+
+type CounterState = {
+  count: number
+};
+
+class CounterContainer extends Container<CounterState> {
+  state = {
+    count: 0
+  };
+
+  increment(amount: number) {
+    this.setState({ count: this.state.count + amount });
+  }
+
+  decrement(amount: number) {
+    this.setState({ count: this.state.count - amount });
+  }
+}
+
+function Counter({ count, increment, decrement }) {
+  return (
+    <div>
+      <span>Count: {count}</span>
+      <button onClick={() => decrement()}>-</button>
+      <button onClick={() => increment()}>+</button>
+    </div>
+  );
+}
+
+const ConnectedCounter = connect(
+  [AppContainer, CounterContainer],
+  (app, counter) => ({
+    count: counter.state.count,
+    decrement: () => counter.decrement(app.state.amount),
+    increment: () => counter.increment(app.state.amount)
+  })
+)(Counter);
+
+function App({ amount, setAmount }) {
+  return (
+    <div>
+      <ConnectedCounter />
+      <label>Amount: </label>
+      <input
+        type="number"
+        value={amount}
+        onChange={event => {
+          setAmount(parseInt(event.currentTarget.value, 10));
+        }}
+      />
+    </div>
+  );
+}
+
+const ConnectedApp = connect(
+  AppContainer,
+  app => ({
+    amount: app.state.amount,
+    setAmount: value => app.setAmount(value)
+  }),
+  app => app.setAmount(2)
+)(App);
+
+render(
+  <Provider>
+    <ConnectedApp />
+  </Provider>,
+  window.connect
+);

--- a/example/index.html
+++ b/example/index.html
@@ -12,5 +12,9 @@
     <h3>Complex</h3>
     <div id="complex"></div>
     <script type="text/javascript" src="./complex.js"></script>
+
+    <h3>Connect</h3>
+    <div id="connect"></div>
+    <script type="text/javascript" src="./connect.js"></script>
   </body>
 </html>


### PR DESCRIPTION
In order to provide a cleaner separation in between the UI components and the internals of the store, I prefer a separate connector that handles the mapping of the store state and actions to the component properties.  

I am sorry I am not good enough with Flow, it is screaming at me, but I have not been able to do any better.  I have been postponing submitting this due to the errors.

I have this working in an application which I can easily switch from Redux to Unstated just by linking folders to one store or the other, and it works just alike in both, since the UI Components don't rely on any particular store.  Each store has a set of *connectors* (react-redux or my own `connect`)  which do the mapping.

Unlike react-redux, my `connect` maps both values and actions in the same object.  Unlike react-redux, my `connect` has an additional optional `init` function that can execute some initial action (in the react-redux connector, I solve it using the [`lifecycle`](https://github.com/acdlite/recompose/blob/master/docs/API.md#lifecycle) HoC from Recompose.