### PR TITLE
Migrate to new version of create-react-context or new React.createContext API

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typescript": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "create-react-context": "^0.1.5"
+    "create-react-context": "^0.2.1"
   },
   "peerDependencies": {
     "prop-types": "^15.5.0",
@@ -30,28 +30,28 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
-    "@types/react": "^16.0.36",
+    "@types/react": "^16.0.40",
     "babel-core": "^6.26.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.26.0",
-    "flow-bin": "^0.64.0",
-    "flow-copy-source": "^1.2.2",
+    "flow-bin": "^0.66.0",
+    "flow-copy-source": "^1.3.0",
     "husky": "^0.14.3",
-    "jest": "^22.1.4",
+    "jest": "^22.4.2",
     "jsdom": "^11.6.2",
-    "lint-staged": "^6.1.0",
-    "parcel-bundler": "^1.5.1",
-    "prettier": "^1.10.2",
-    "prop-types": "^15.6.0",
+    "lint-staged": "^7.0.0",
+    "parcel-bundler": "^1.6.2",
+    "prettier": "^1.11.1",
+    "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-test-renderer": "^16.2.0",
-    "rollup": "^0.55.3",
+    "rollup": "^0.56.3",
     "rollup-plugin-babel": "^3.0.3",
-    "typescript": "^2.7.1"
+    "typescript": "^2.7.2"
   },
   "lint-staged": {
     "*.{js,json,md}": ["prettier --write", "git add"]

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -119,23 +119,17 @@ export type ProviderProps = {
 };
 
 export function Provider(props: ProviderProps) {
+  const childMap = new Map();
+
+  if (props.inject) {
+    props.inject.forEach(instance => {
+      childMap.set(instance.constructor, instance);
+    });
+  }
+
   return (
-    <StateContext.Consumer>
-      {parentMap => {
-        let childMap = new Map(parentMap);
-
-        if (props.inject) {
-          props.inject.forEach(instance => {
-            childMap.set(instance.constructor, instance);
-          });
-        }
-
-        return (
-          <StateContext.Provider value={childMap}>
-            {props.children}
-          </StateContext.Provider>
-        );
-      }}
-    </StateContext.Consumer>
+    <StateContext.Provider value={childMap}>
+      {props.children}
+    </StateContext.Provider>
   );
 }


### PR DESCRIPTION
I just have a bit confused why you need to wrap <StateContext.Consumer> in the Provider Component.