### PR TITLE
Possible solution for deprecated componentWillReceiveProps?

### DIFF
--- a/src/unstated.js
+++ b/src/unstated.js
@@ -52,7 +52,7 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
   state = {};
   instances: Array<ContainerType> = [];
 
-  componentWillReceiveProps() {
+  componentDidUpdate() {
     this._unsubscribe();
   }
 

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -52,10 +52,6 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
   state = {};
   instances: Array<ContainerType> = [];
 
-  componentDidUpdate() {
-    this._unsubscribe();
-  }
-
   componentWillUnmount() {
     this._unsubscribe();
   }
@@ -74,6 +70,8 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
     map: ContainerMapType | null,
     containers: ContainersType
   ): Array<ContainerType> {
+    this._unsubscribe();
+                       
     if (map === null) {
       throw new Error(
         'You must wrap your <Subscribe> components with a <Provider>'


### PR DESCRIPTION
Since react v 16.3 is deprecating `componentWillReceiveProps` can `componentDidUpdate` act as a viable solution here? I wanted to use `getDerivedStateFromProps`, but it has no access to `this`.

Given that `componentDidMount` happens after `componentWillReceiveProps` I am cautious about this and checking here.