### PR TITLE
Remove react-dom from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.0",
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.0.36",


### PR DESCRIPTION
As far as I can tell, Unstated doesn't need `react-dom` at all. I'm using it in React Native and the package manager warnings bother some people. 😉 