### PR TITLE
Align Container#setState closer to React's implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,54 @@ subscribe to for updates. When you call `setState` it triggers components to
 re-render, be careful not to mutate `this.state` directly or your components
 won't re-render.
 
+###### `setState()`
+
+`setState()` in `Container` mimics React's `setState()` method as closely as
+possible.
+
+```js
+class CounterContainer extends Container {
+  state = { count: 0 };
+  increment = () => {
+    this.setState(
+      state => {
+        return { count: state.count + 1 };
+      },
+      () => {
+        console.log('Updated!');
+      }
+    );
+  };
+}
+```
+
+It's also run asynchronously, so you need to follow the same rules as React.
+
+**Don't read state immediately after setting it**
+
+```js
+class CounterContainer extends Container {
+  state = { count: 0 };
+  increment = () => {
+    this.setState({ count: 1 });
+    console.log(this.state.count); // 0
+  };
+}
+```
+
+**If you are using previous state to calculate the next state, use the function form**
+
+```js
+class CounterContainer extends Container {
+  state = { count: 0 };
+  increment = () => {
+    this.setState(state => {
+      return { count: state.count + 1 };
+    });
+  };
+}
+```
+
 ##### `<Subscribe>`
 
 Next we'll need a piece to introduce our state back into the tree so that:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "typescript": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "create-react-context": "^0.1.5"
+    "create-react-context": "^0.1.5",
+    "tickedoff": "^1.0.1"
   },
   "peerDependencies": {
     "prop-types": "^15.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5134,6 +5134,10 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
+tickedoff@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tickedoff/-/tickedoff-1.0.1.tgz#277c463b5b275dc3c7e7473f8eef804254b9002d"
+
 timers-browserify@^2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.6.tgz#241e76927d9ca05f4d959819022f5b3664b64bae"


### PR DESCRIPTION
This is an initial attempt at making Unstated's `Container#setState` work more like React's `Component#setState`.

**`setState` is async**

```js
this.setState({ value: 'foo' });
this.state.value; // 'prevValue'
```

**`updater` can be a function**

```js
this.setState(prevState => ({ counter: prevState.counter + 1 }));
```

**An optional `callback` will run after the component's are updated**

```js
this.setState({}, () => {
  // components are updated
});
```