### PR TITLE
Prevent state update warning after subscribe component is already unmounted

### DIFF
--- a/src/unstated.js
+++ b/src/unstated.js
@@ -47,11 +47,16 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
     children: PropTypes.func.isRequired
   };
 
+  mounted = false;
   state = {};
   instances: Array<ContainerType> = [];
 
+  componentDidMount() {
+    this.mounted = true;
+  }
   componentWillUnmount() {
     this._unsubscribe();
+    this.mounted = false;
   }
 
   _unsubscribe() {
@@ -61,7 +66,9 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
   }
 
   onUpdate = () => {
-    this.setState(DUMMY_STATE);
+    if (this.mounted) {
+      this.setState(DUMMY_STATE);
+    }
   };
 
   _createInstances(
@@ -69,7 +76,7 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
     containers: ContainersType
   ): Array<ContainerType> {
     this._unsubscribe();
-                       
+
     if (map === null) {
       throw new Error(
         'You must wrap your <Subscribe> components with a <Provider>'


### PR DESCRIPTION
I'm using unstated in conjunction with react-router. I have an auth container which keeps track of the authentication state (is logged in). In the component tree I have a subscriber at one level, and another subscriber a few levels down. Essentially creating 
```
<Provider>
  ...
  <Subscribe> 
    ...
    <Subscribe>
      // components that use the container
    </Subscribe>
    ...
  </Subscribe>
  ...
</Provider>
```

The user can log in from the deepest <Subscribe> component by doing `auth.login()`. This then triggers a state change in the container and everything renders again. The render method renders a <Redirect /> when the user is logged in. The Redirect causes the whole tree to be re-rendered (as it's a different route) so both the Subscribers will be unmounted.

It works, however it does trigger a warning in this case because the container loops over the listeners on setState, and in my case it just to happens to be that the first update was the deepest Subscribe which in turn renders the redirect, so the other Subscribe component doesn't exist anymore by the time that listener is called, and triggering the warning.

I've implemented a small piece of logic that keeps track if the component is mounted, and doesn't update state if it's not mounted, to prevent the warning. I'm having a bit of difficulty setting up a test for this without replicating a react router situation in the __tests__ folder. Any idea how this is easier to replicate in a test?
