### PR TITLE
Fix Class definition in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ which accepts `props` sorta like React components. Then create your own
 instance of your container and pass it into `<Provide inject>`.
 
 ```js
-class CounterContainer {
+class CounterContainer extends Container {
   constructor(props = {}) {
     super();
     this.state = {


### PR DESCRIPTION
I presume that this Class definition is meant to extend the Container class, as in the other examples shown above.