### PR TITLE
Possible fix for error introduced in v2: defer is not a function

### DIFF
--- a/src/unstated.js
+++ b/src/unstated.js
@@ -2,7 +2,7 @@
 import React, { type Node } from 'react';
 import createReactContext from 'create-react-context';
 import PropTypes from 'prop-types';
-import defer from 'tickedoff';
+import tickedoff from 'tickedoff';
 
 type Listener = (cb?: () => void) => void;
 
@@ -20,7 +20,7 @@ export class Container<State: {}> {
     updater: $Shape<State> | ((prevState: $Shape<State>) => $Shape<State>),
     callback?: () => void
   ) {
-    defer(() => {
+    tickedoff(() => {
       let nextState;
 
       if (typeof updater === 'function') {


### PR DESCRIPTION
I'm not sire if this is a proper solution, as I haven't worked with module.export, but since 1.2.0 version change to 2.0.0 I started getting 

> defer is not a function


after inspecing source it seems to be coming from another package `tickedoff` that exports module named `tickedoff` instead of `defere` 