### PR TITLE
Allow passing options to Container

### DIFF
--- a/src/unstated.d.ts
+++ b/src/unstated.d.ts
@@ -11,7 +11,7 @@ export class Container<State extends object> {
 }
 
 export interface ContainerType<State extends object> {
-  new (): Container<State>;
+  new (...args: any[]): Container<State>;
 }
 
 interface SubscribeProps {


### PR DESCRIPTION
Per FAQ, Container can be instantiated with constructor props. Updating types to allow props.