### PR TITLE
Minor correction to TypeScript `setState` type

### DIFF
--- a/src/unstated.d.ts
+++ b/src/unstated.d.ts
@@ -4,8 +4,8 @@ export class Container<State extends object> {
   state: State;
   setState<K extends keyof State>(
     state:
-      | ((prevState: Readonly<State>) => Partial<State> | State | null)
-      | (Partial<State> | State | null),
+      | ((prevState: Readonly<State>) => Pick<State, K> | State | null)
+      | (Pick<State, K> | State | null),
     callback?: () => void
   ): Promise<void>;
   subscribe(fn: () => any): void;


### PR DESCRIPTION
Instead of allowing a `Partial<State>` to when calling `setState`, allow `Pick<State, K>` instead. Honestly, it looks like someone meant to do this in the first place but missed it, as the `K` generic type was already declared.

This is a legitimate bug. Imagine that state is of type `{ x: number }`, and I try to call `setState({ x: undefined })`.
With `Partial`, that's totally valid, because `Partial` creates a new type with the same keys, but each "optional". Of course, optional allows `undefined`.
`Pick`, on the other hand, maps to a new type that only has a subset of the original keys but maintains the type of the remaining keys. So `{}` would be a valid argument, because it has the empty set of keys, but `{ x: undefined }` is out because `x` still needs to be a number.

This is in line with the React version:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L296