### PR TITLE
Change name of Container to Carrier

### DIFF
--- a/__tests__/unstated.js
+++ b/__tests__/unstated.js
@@ -1,13 +1,13 @@
 // @flow
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { Provider, Subscribe, Container } from '../src/unstated';
+import { Provider, Subscribe, Carrier } from '../src/unstated';
 
 function render(element) {
   return renderer.create(element).toJSON();
 }
 
-class CounterContainer extends Container<{ count: number }> {
+class CounterCarrier extends Carrier<{ count: number }> {
   state = { count: 0 };
   increment(amount = 1) {
     this.setState({ count: this.state.count + amount });
@@ -17,7 +17,7 @@ class CounterContainer extends Container<{ count: number }> {
   }
 }
 
-class AmounterContainer extends Container<{ amount: number }> {
+class AmounterCarrier extends Carrier<{ amount: number }> {
   state = { amount: 1 };
   setAmount(amount) {
     this.setState({ amount });
@@ -26,7 +26,7 @@ class AmounterContainer extends Container<{ amount: number }> {
 
 function Counter() {
   return (
-    <Subscribe to={[CounterContainer]}>
+    <Subscribe to={[CounterCarrier]}>
       {counter => (
         <div>
           <span>{counter.state.count}</span>
@@ -40,7 +40,7 @@ function Counter() {
 
 function CounterWithAmount() {
   return (
-    <Subscribe to={[CounterContainer, AmounterContainer]}>
+    <Subscribe to={[CounterCarrier, AmounterCarrier]}>
       {(counter, amounter) => (
         <div>
           <span>{counter.state.count}</span>
@@ -58,7 +58,7 @@ function CounterWithAmount() {
 
 function CounterWithAmountApp() {
   return (
-    <Subscribe to={[AmounterContainer]}>
+    <Subscribe to={[AmounterCarrier]}>
       {amounter => (
         <div>
           <Counter />

--- a/__tests__/unstated.tsx
+++ b/__tests__/unstated.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Provider, Subscribe, Container } from '../src/unstated';
+import { Provider, Subscribe, Carrier } from '../src/unstated';
 
-class CounterContainer extends Container<{ count: number }> {
+class CounterCarrier extends Carrier<{ count: number }> {
   state = { count: 0 };
   increment(amount = 1) {
     this.setState({ count: this.state.count + amount });
@@ -11,7 +11,7 @@ class CounterContainer extends Container<{ count: number }> {
   }
 }
 
-class AmounterContainer extends Container<{ amount: number }> {
+class AmounterCarrier extends Carrier<{ amount: number }> {
   state = { amount: 1 };
   setAmount(amount: number) {
     this.setState({ amount });
@@ -20,8 +20,8 @@ class AmounterContainer extends Container<{ amount: number }> {
 
 function Counter() {
   return (
-    <Subscribe to={[CounterContainer]}>
-      {(counter: CounterContainer) => (
+    <Subscribe to={[CounterCarrier]}>
+      {(counter: CounterCarrier) => (
         <div>
           <span>{counter.state.count}</span>
           <button onClick={() => counter.decrement()}>-</button>
@@ -34,8 +34,8 @@ function Counter() {
 
 function CounterWithAmount() {
   return (
-    <Subscribe to={[CounterContainer, AmounterContainer]}>
-      {(counter: CounterContainer, amounter: AmounterContainer) => (
+    <Subscribe to={[CounterCarrier, AmounterCarrier]}>
+      {(counter: CounterCarrier, amounter: AmounterCarrier) => (
         <div>
           <span>{counter.state.count}</span>
           <button onClick={() => counter.decrement(amounter.state.amount)}>
@@ -52,8 +52,8 @@ function CounterWithAmount() {
 
 function CounterWithAmountApp() {
   return (
-    <Subscribe to={[AmounterContainer]}>
-      {(amounter: AmounterContainer) => (
+    <Subscribe to={[AmounterCarrier]}>
+      {(amounter: AmounterCarrier) => (
         <div>
           <Counter />
           <input
@@ -69,12 +69,12 @@ function CounterWithAmountApp() {
   );
 }
 
-const sharedAmountContainer = new AmounterContainer();
+const sharedAmountCarrier = new AmounterCarrier();
 
 function CounterWithSharedAmountApp() {
   return (
-    <Subscribe to={[sharedAmountContainer]}>
-      {(amounter: AmounterContainer) => (
+    <Subscribe to={[sharedAmountCarrier]}>
+      {(amounter: AmounterCarrier) => (
         <div>
           <Counter />
           <input
@@ -90,7 +90,7 @@ function CounterWithSharedAmountApp() {
   );
 }
 
-let counter = new CounterContainer();
+let counter = new CounterCarrier();
 let render = () => (
   <Provider inject={[counter]}>
     <Counter />

--- a/example/complex.js
+++ b/example/complex.js
@@ -1,13 +1,13 @@
 // @flow
 import React from 'react';
 import { render } from 'react-dom';
-import { Provider, Subscribe, Container } from '../src/unstated';
+import { Provider, Subscribe, Carrier } from '../src/unstated';
 
 type AppState = {
   amount: number
 };
 
-class AppContainer extends Container<AppState> {
+class AppCarrier extends Carrier<AppState> {
   state = {
     amount: 1
   };
@@ -21,7 +21,7 @@ type CounterState = {
   count: number
 };
 
-class CounterContainer extends Container<CounterState> {
+class CounterCarrier extends Carrier<CounterState> {
   state = {
     count: 0
   };
@@ -37,7 +37,7 @@ class CounterContainer extends Container<CounterState> {
 
 function Counter() {
   return (
-    <Subscribe to={[AppContainer, CounterContainer]}>
+    <Subscribe to={[AppCarrier, CounterCarrier]}>
       {(app, counter) => (
         <div>
           <span>Count: {counter.state.count}</span>
@@ -51,7 +51,7 @@ function Counter() {
 
 function App() {
   return (
-    <Subscribe to={[AppContainer]}>
+    <Subscribe to={[AppCarrier]}>
       {app => (
         <div>
           <Counter />

--- a/example/shared.js
+++ b/example/shared.js
@@ -1,13 +1,13 @@
 // @flow
 import React from 'react';
 import { render } from 'react-dom';
-import { Provider, Subscribe, Container } from '../src/unstated';
+import { Provider, Subscribe, Carrier } from '../src/unstated';
 
 type CounterState = {
   count: number
 };
 
-class CounterContainer extends Container<CounterState> {
+class CounterCarrier extends Carrier<CounterState> {
   state = { count: 0 };
 
   increment() {
@@ -19,16 +19,16 @@ class CounterContainer extends Container<CounterState> {
   }
 }
 
-const sharedCounterContainer = new CounterContainer();
+const sharedCounterCarrier = new CounterCarrier();
 
 function Counter() {
   return (
-    <Subscribe to={[sharedCounterContainer]}>
+    <Subscribe to={[sharedCounterCarrier]}>
       {counter => (
         <div>
           <button onClick={() => counter.decrement()}>-</button>
           <span>{counter.state.count}</span>
-          <button onClick={() => sharedCounterContainer.increment()}>+</button>
+          <button onClick={() => sharedCounterCarrier.increment()}>+</button>
         </div>
       )}
     </Subscribe>

--- a/example/simple.js
+++ b/example/simple.js
@@ -1,13 +1,13 @@
 // @flow
 import React from 'react';
 import { render } from 'react-dom';
-import { Provider, Subscribe, Container } from '../src/unstated';
+import { Provider, Subscribe, Carrier } from '../src/unstated';
 
 type CounterState = {
   count: number
 };
 
-class CounterContainer extends Container<CounterState> {
+class CounterCarrier extends Carrier<CounterState> {
   state = { count: 0 };
 
   increment() {
@@ -21,7 +21,7 @@ class CounterContainer extends Container<CounterState> {
 
 function Counter() {
   return (
-    <Subscribe to={[CounterContainer]}>
+    <Subscribe to={[CounterCarrier]}>
       {counter => (
         <div>
           <button onClick={() => counter.decrement()}>-</button>

--- a/src/unstated.d.ts
+++ b/src/unstated.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export class Container<State extends object> {
+export class Carrier<State extends object> {
   state: State;
   setState<K extends keyof State>(
     state:
@@ -12,19 +12,19 @@ export class Container<State extends object> {
   unsubscribe(fn: () => any): void;
 }
 
-export interface ContainerType<State extends object> {
-  new (...args: any[]): Container<State>;
+export interface CarrierType<State extends object> {
+  new (...args: any[]): Carrier<State>;
 }
 
 interface SubscribeProps {
-  to: (ContainerType<any> | Container<any>)[];
-  children(...instances: Container<any>[]): React.ReactNode;
+  to: (CarrierType<any> | Carrier<any>)[];
+  children(...instances: Carrier<any>[]): React.ReactNode;
 }
 
 export class Subscribe extends React.Component<SubscribeProps> {}
 
 export interface ProviderProps {
-  inject?: Container<any>[];
+  inject?: Carrier<any>[];
   children: React.ReactNode;
 }
 

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -6,12 +6,12 @@ type Listener = () => mixed;
 
 const StateContext = createReactContext(null);
 
-export class Container<State: {}> {
+export class Carrier<State: {}> {
   state: State;
   _listeners: Array<Listener> = [];
 
   constructor() {
-    CONTAINER_DEBUG_CALLBACKS.forEach(cb => cb(this));
+    Carrier_DEBUG_CALLBACKS.forEach(cb => cb(this));
   }
 
   setState(
@@ -53,14 +53,14 @@ export class Container<State: {}> {
   }
 }
 
-export type ContainerType = Container<Object>;
-export type ContainersType = Array<Class<ContainerType> | ContainerType>;
-export type ContainerMapType = Map<Class<ContainerType>, ContainerType>;
+export type CarrierType = Carrier<Object>;
+export type CarriersType = Array<Class<CarrierType> | CarrierType>;
+export type CarrierMapType = Map<Class<CarrierType>, CarrierType>;
 
-export type SubscribeProps<Containers: ContainersType> = {
-  to: Containers,
+export type SubscribeProps<Carriers: CarriersType> = {
+  to: Carriers,
   children: (
-    ...instances: $TupleMap<Containers, <C>(Class<C> | C) => C>
+    ...instances: $TupleMap<Carriers, <C>(Class<C> | C) => C>
   ) => Node
 };
 
@@ -68,12 +68,12 @@ type SubscribeState = {};
 
 const DUMMY_STATE = {};
 
-export class Subscribe<Containers: ContainersType> extends React.Component<
-  SubscribeProps<Containers>,
+export class Subscribe<Carriers: CarriersType> extends React.Component<
+  SubscribeProps<Carriers>,
   SubscribeState
 > {
   state = {};
-  instances: Array<ContainerType> = [];
+  instances: Array<CarrierType> = [];
   unmounted = false;
 
   componentWillUnmount() {
@@ -82,8 +82,8 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
   }
 
   _unsubscribe() {
-    this.instances.forEach(container => {
-      container.unsubscribe(this.onUpdate);
+    this.instances.forEach(Carrier => {
+      Carrier.unsubscribe(this.onUpdate);
     });
   }
 
@@ -98,9 +98,9 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
   };
 
   _createInstances(
-    map: ContainerMapType | null,
-    containers: ContainersType
-  ): Array<ContainerType> {
+    map: CarrierMapType | null,
+    Carriers: CarriersType
+  ): Array<CarrierType> {
     this._unsubscribe();
 
     if (map === null) {
@@ -110,20 +110,20 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
     }
 
     let safeMap = map;
-    let instances = containers.map(ContainerItem => {
+    let instances = Carriers.map(CarrierItem => {
       let instance;
 
       if (
-        typeof ContainerItem === 'object' &&
-        ContainerItem instanceof Container
+        typeof CarrierItem === 'object' &&
+        CarrierItem instanceof Carrier
       ) {
-        instance = ContainerItem;
+        instance = CarrierItem;
       } else {
-        instance = safeMap.get(ContainerItem);
+        instance = safeMap.get(CarrierItem);
 
         if (!instance) {
-          instance = new ContainerItem();
-          safeMap.set(ContainerItem, instance);
+          instance = new CarrierItem();
+          safeMap.set(CarrierItem, instance);
         }
       }
 
@@ -152,7 +152,7 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
 }
 
 export type ProviderProps = {
-  inject?: Array<ContainerType>,
+  inject?: Array<CarrierType>,
   children: Node
 };
 
@@ -178,12 +178,12 @@ export function Provider(props: ProviderProps) {
   );
 }
 
-let CONTAINER_DEBUG_CALLBACKS = [];
+let Carrier_DEBUG_CALLBACKS = [];
 
 // If your name isn't Sindre, this is not for you.
 // I might ruin your day suddenly if you depend on this without talking to me.
-export function __SUPER_SECRET_CONTAINER_DEBUG_HOOK__(
-  callback: (container: Container<any>) => mixed
+export function __SUPER_SECRET_Carrier_DEBUG_HOOK__(
+  callback: (Carrier: Carrier<any>) => mixed
 ) {
-  CONTAINER_DEBUG_CALLBACKS.push(callback);
+  Carrier_DEBUG_CALLBACKS.push(callback);
 }


### PR DESCRIPTION
Changed the name of Container to Carrier

This change is to make unstated syntactically work better with other libraries and naming conventions. "Container" in vanilla React is used commonly to encapsulate tags. In addition, "Container" is used in other UI libraries. Trying to come up with other names on one's own like "Box" or "Holder" conflict with other conventions.

The proposal for Carrier fits the purpose of Container but in a more deliberate way for props passing.