### PR TITLE
Fix listeners leak when using with componentDidCatch

### DIFF
--- a/src/unstated.js
+++ b/src/unstated.js
@@ -76,9 +76,20 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
   instances: Array<ContainerType> = [];
   unmounted = false;
 
+  componentDidMount() {
+    this._subscribe();
+  }
+
   componentWillUnmount() {
     this.unmounted = true;
     this._unsubscribe();
+  }
+
+  _subscribe() {
+    this.instances.forEach(container => {
+      container.unsubscribe(this.onUpdate);
+      container.subscribe(this.onUpdate);
+    });
   }
 
   _unsubscribe() {
@@ -126,9 +137,6 @@ export class Subscribe<Containers: ContainersType> extends React.Component<
           safeMap.set(ContainerItem, instance);
         }
       }
-
-      instance.unsubscribe(this.onUpdate);
-      instance.subscribe(this.onUpdate);
 
       return instance;
     });


### PR DESCRIPTION
⚠️ *This PR is not ready to be merged, neither tested. I'm opening it now to gather feedback and suggestions of solutions that I may have missed.*

I investigated a bug in my application coming from the use of `unstated` and `componentDidCatch`.

At some point `container.setState` was returning a never-fulfilled promise. React was logging:

```
warning.js:33 Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in Subscribe
    in Fetch
    in FetchBoundary (created by ViewTable)
    in ViewTable (created by SecondaryView)
    in SecondaryView
```

When an error is thrown during the render phase, the [`componentWillUnmount`](https://github.com/jamiebuilds/unstated/blob/master/src/unstated.js#L81) is never called, and the component doesn't unsubscribe from the container.

When calling `setState`, since the component for the listener is unmounted, [`onUpdate` returns a never-fulfilled promise](https://github.com/jamiebuilds/unstated/blob/master/src/unstated.js#L92).

**Potential solution:** I'm experimenting moving the subscribe calls to a safe place `componentDidMount` (which happens during the commit phase, see [this comment](https://github.com/gaearon/react-side-effect/issues/40#issuecomment-367129253) that explains it).

Any way, I'd love to get your feedback on what could be the best approach to fix this 🙌

---

TLDR: When using `unstated` with `componentDidCatch`, it leaks listeners, and prevent `setState` from being fulfilled.

