### PR TITLE
Connect function similar to Redux

### DIFF
--- a/src/unstated.js
+++ b/src/unstated.js
@@ -188,8 +188,8 @@ export function __SUPER_SECRET_CONTAINER_DEBUG_HOOK__(
   CONTAINER_DEBUG_CALLBACKS.push(callback);
 }
 
-export function Connect(subscribeTo = []) {
-  return Component => props => (
+export function Connect(subscribeTo: ContainersType) {
+  return Component: Object => props: Object => (
     <Subscribe to={subscribeTo}>
       {(...containers) => {
         // Transform containers array into object

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -187,3 +187,21 @@ export function __SUPER_SECRET_CONTAINER_DEBUG_HOOK__(
 ) {
   CONTAINER_DEBUG_CALLBACKS.push(callback);
 }
+
+export function Connect(subscribeTo = []) {
+  return Component => props => (
+    <Subscribe to={subscribeTo}>
+      {(...containers) => {
+        // Transform containers array into object
+        // The class name will be the key of each container
+        let mapContainersToProps = containers.reduce(
+          (acc, cur) => ((acc[cur.constructor.name] = cur), acc),
+          {}
+        );
+
+        // Pass containers as props
+        return <Component {...mapContainersToProps} {...props} />;
+      }}
+    </Subscribe>
+  );
+}


### PR DESCRIPTION
A simple HOC that inscribes in a container very similar to Redux.

Example:
```js
class HomePage extends Component {
  render() {
    const { CounterContainer } = this.props

    return (
      <div>
        <span>{CounterContainer.state.count}</span>
        <button onClick={CounterContainer.decrement}>-</button>
        <button onClick={CounterContainer.increment}>+</button>
      </div>
    )
  }
}

export default Connect([CounterContainer])(HomePage)
```

What do you think? If you accept this change I will put in the documentation in README.