### PR TITLE
test: adding unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 lib
 .cache
 dist
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
 cache:
   yarn: true
   directories:
-  - node_modules
-script: 
-  - yarn test && yarn flow
+    - node_modules
+script:
+  - yarn test --coverage && yarn flow
   - yarn typescript

--- a/__tests__/unstated.js
+++ b/__tests__/unstated.js
@@ -9,7 +9,7 @@ function render(element) {
 }
 
 async function click({ children = [] }, id) {
-  const el = children.find(({ props = {} }) => props.id === id);
+  const el: any = children.find(({ props = {} }) => props.id === id);
   el.props.onClick();
 }
 

--- a/__tests__/unstated.js
+++ b/__tests__/unstated.js
@@ -75,3 +75,10 @@ test('should remove subscriber listeners if component is unmounted', () => {
   expect(counter._listeners.length).toBe(0);
   expect(testInstance.unmounted).toBe(true);
 });
+
+test('should throw an error if <Subscribe> component is not wrapper with <Provider>', () => {
+  spyOn(console, 'error');
+  expect(() => render(<Counter />)).toThrowError(
+    'You must wrap your <Subscribe> components with a <Provider>'
+  );
+});

--- a/__tests__/unstated.js
+++ b/__tests__/unstated.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { Provider, Subscribe, Container } from '../src/unstated';
-import { createImportSpecifier } from 'typescript';
 
 function render(element) {
   return renderer.create(element).toJSON();

--- a/__tests__/unstated.js
+++ b/__tests__/unstated.js
@@ -1,10 +1,16 @@
 // @flow
 import React from 'react';
+import assert from 'assert';
 import renderer from 'react-test-renderer';
 import { Provider, Subscribe, Container } from '../src/unstated';
 
 function render(element) {
   return renderer.create(element).toJSON();
+}
+
+async function click({ children = [] }, id) {
+  const el = children.find(({ props = {} }) => props.id === id);
+  el.props.onClick();
 }
 
 class CounterContainer extends Container<{ count: number }> {
@@ -30,8 +36,12 @@ function Counter() {
       {counter => (
         <div>
           <span>{counter.state.count}</span>
-          <button onClick={() => counter.decrement()}>-</button>
-          <button onClick={() => counter.increment()}>+</button>
+          <button id="decrement" onClick={() => counter.decrement()}>
+            -
+          </button>
+          <button id="increment" onClick={() => counter.increment()}>
+            +
+          </button>
         </div>
       )}
     </Subscribe>
@@ -75,6 +85,19 @@ function CounterWithAmountApp() {
   );
 }
 
-test('basic', () => {
-  // still too lazy
+test('counter', async () => {
+  let counter = new CounterContainer();
+  let tree = render(
+    <Provider inject={[counter]}>
+      <Counter />
+    </Provider>
+  );
+
+  assert.equal(counter.state.count, 0);
+
+  await click(tree, 'increment');
+  assert.equal(counter.state.count, 1);
+
+  await click(tree, 'decrement');
+  assert.equal(counter.state.count, 0);
 });

--- a/package.json
+++ b/package.json
@@ -53,15 +53,5 @@
   },
   "lint-staged": {
     "*.{js,json,md}": ["prettier --write", "git add"]
-  },
-  "jest": {
-    "coverageThreshold": {
-      "global": {
-        "lines": 82,
-        "statements": 80,
-        "functions": 90,
-        "branches": 50
-      }
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
     "collectCoverageFrom": ["src/**/*.js"],
     "coverageThreshold": {
       "global": {
-        "lines": 76,
-        "statements": 74,
-        "functions": 86,
+        "lines": 80,
+        "statements": 78,
+        "functions": 90,
         "branches": 45
       }
     }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,18 @@
   },
   "lint-staged": {
     "*.{js,json,md}": ["prettier --write", "git add"]
+  },
+  "jest": {
+    "collectCoverage": true,
+    "coverageDirectory": "coverage",
+    "collectCoverageFrom": ["src/**/*.js"],
+    "coverageThreshold": {
+      "global": {
+        "lines": 76,
+        "statements": 74,
+        "functions": 86,
+        "branches": 45
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "collectCoverageFrom": ["src/**/*.js"],
     "coverageThreshold": {
       "global": {
-        "lines": 80,
-        "statements": 78,
+        "lines": 82,
+        "statements": 80,
         "functions": 90,
-        "branches": 45
+        "branches": 50
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -55,9 +55,6 @@
     "*.{js,json,md}": ["prettier --write", "git add"]
   },
   "jest": {
-    "collectCoverage": true,
-    "coverageDirectory": "coverage",
-    "collectCoverageFrom": ["src/**/*.js"],
     "coverageThreshold": {
       "global": {
         "lines": 82,


### PR DESCRIPTION
- Adding unit tests into the package;
- Ignoring `coverage` folder;
- Adding jest code coverage. The idea is to add a code coverage badge integration service (like coveralls or similar) later on and avoid to decrease the code coverage;
