### PR TITLE
Type-safe Subscribe component in TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-test-renderer": "^16.2.0",
     "rollup": "^0.55.3",
     "rollup-plugin-babel": "^3.0.3",
-    "typescript": "^2.7.1"
+    "typescript": "^2.8.0"
   },
   "lint-staged": {
     "*.{js,json,md}": ["prettier --write", "git add"]

--- a/src/unstated.d.ts
+++ b/src/unstated.d.ts
@@ -4,8 +4,8 @@ export class Container<State extends object> {
   state: State;
   setState<K extends keyof State>(
     state:
-      | ((prevState: Readonly<State>) => Pick<State, K> | State | null)
-      | (Pick<State, K> | State | null),
+      | ((prevState: Readonly<State>) => Partial<State> | State | null)
+      | (Partial<State> | State | null),
     callback?: () => void
   ): Promise<void>;
   subscribe(fn: () => any): void;
@@ -16,12 +16,38 @@ export interface ContainerType<State extends object> {
   new (...args: any[]): Container<State>;
 }
 
+interface SubscribeProps1<T extends ContainerType<any>> {
+  to: [T];
+  children(input: InstanceType<T>): React.ReactNode
+}
+interface SubscribeProps2<T extends ContainerType<any>, U extends ContainerType<any>> {
+  to: [T,U];
+  children(input: InstanceType<T>, input2: InstanceType<U>): React.ReactNode
+}
+interface SubscribeProps3<T extends ContainerType<any>, U extends ContainerType<any>, V extends ContainerType<any>> {
+  to: [T,U,V];
+  children(input: InstanceType<T>, input2: InstanceType<U>, input3: InstanceType<V>): React.ReactNode
+}
+interface SubscribeProps4<T extends ContainerType<any>, U extends ContainerType<any>, V extends ContainerType<any>, W extends ContainerType<any>> {
+  to: [T,U,V,W];
+  children(input: InstanceType<T>, input2: InstanceType<U>, input3: InstanceType<V>, input4: InstanceType<W>): React.ReactNode
+}
+interface SubscribeProps5<T extends ContainerType<any>, U extends ContainerType<any>, V extends ContainerType<any>, W extends ContainerType<any>, X extends ContainerType<any>> {
+  to: [T,U,V,W, X];
+  children(input: InstanceType<T>, input2: InstanceType<U>, input3: InstanceType<V>, input4: InstanceType<W>, input5: InstanceType<X>): React.ReactNode
+}
+
 interface SubscribeProps {
   to: (ContainerType<any> | Container<any>)[];
   children(...instances: Container<any>[]): React.ReactNode;
 }
 
-export class Subscribe extends React.Component<SubscribeProps> {}
+export function Subscribe<T extends ContainerType<any>>(props: SubscribeProps1<T>): React.ReactNode;
+export function Subscribe<T extends ContainerType<any>, U extends ContainerType<any>>(props: SubscribeProps2<T, U>): React.ReactNode;
+export function Subscribe<T extends ContainerType<any>, U extends ContainerType<any>, V extends ContainerType<any>>(props: SubscribeProps3<T, U,V>): React.ReactNode;
+export function Subscribe<T extends ContainerType<any>, U extends ContainerType<any>, V extends ContainerType<any>, W extends ContainerType<any>>(props: SubscribeProps4<T, U,V, W>): React.ReactNode;
+export function Subscribe<T extends ContainerType<any>, U extends ContainerType<any>, V extends ContainerType<any>, W extends ContainerType<any>, X extends ContainerType<any>>(props: SubscribeProps5<T, U,V, W, X>): React.ReactNode;
+export function Subscribe(props: SubscribeProps): React.ReactNode;
 
 export interface ProviderProps {
   inject?: Container<any>[];

--- a/src/unstated.d.ts
+++ b/src/unstated.d.ts
@@ -4,8 +4,8 @@ export class Container<State extends object> {
   state: State;
   setState<K extends keyof State>(
     state:
-      | ((prevState: Readonly<State>) => Partial<State> | State | null)
-      | (Partial<State> | State | null),
+    | ((prevState: Readonly<State>) => Pick<State, K> | State | null)
+    | (Pick<State, K> | State | null),
     callback?: () => void
   ): Promise<void>;
   subscribe(fn: () => any): void;

--- a/src/unstated.d.ts
+++ b/src/unstated.d.ts
@@ -4,8 +4,8 @@ export class Container<State extends object> {
   state: State;
   setState<K extends keyof State>(
     state:
-    | ((prevState: Readonly<State>) => Pick<State, K> | State | null)
-    | (Pick<State, K> | State | null),
+      | ((prevState: Readonly<State>) => Pick<State, K> | State | null)
+      | (Pick<State, K> | State | null),
     callback?: () => void
   ): Promise<void>;
   subscribe(fn: () => any): void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5223,9 +5223,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
+typescript@^2.8.0:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
for less than 6 containers. Requires TypeScript 2.8 or later.