### PR TITLE
Add annotation to fix type error in Flow version >=0.85.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.26.0",
-    "flow-bin": "^0.64.0",
+    "flow-bin": "^0.87.0",
     "flow-copy-source": "^1.2.2",
     "husky": "^0.14.3",
     "jest": "^22.1.4",

--- a/src/unstated.js
+++ b/src/unstated.js
@@ -1,10 +1,10 @@
 // @flow
 import React, { type Node } from 'react';
-import createReactContext from 'create-react-context';
+import createReactContext, { type Context } from 'create-react-context';
 
 type Listener = () => mixed;
 
-const StateContext = createReactContext(null);
+const StateContext: Context<ContainerMapType | null> = createReactContext(null);
 
 export class Container<State: {}> {
   state: State;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1953,9 +1953,10 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.64.0:
-  version "0.64.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.64.0.tgz#ddd3fb3b183ab1ab35a5d5dec9caf5ebbcded167"
+flow-bin@^0.87.0:
+  version "0.87.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.87.0.tgz#fab7f984d8cc767e93fa9eb01cf7d57ed744f19d"
+  integrity sha512-mnvBXXZkUp4y6A96bR5BHa3q1ioIIN2L10w5osxJqagAakTXFYZwjl0t9cT3y2aCEf1wnK6n91xgYypQS/Dqbw==
 
 flow-copy-source@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
This fixes the same issue that was addressed by PR #66 Update Flow. But this version of the fix does not require upgrading any dependencies besides flow-bin. I am submitting a new PR because #66 seems not to have been finished.