### PR TITLE
Add polyfill instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 yarn add unstated
 ```
 
+> `Promise` and `Object.assign` are used, Polyfills should be added if necessary
+
 ## Example
 
 ```jsx


### PR DESCRIPTION
I struggled to find out that `Object.assign` is used in unstated,
Chrome debugger for Android 4.4  gives little information about what happened
so I think maybe this better be added in readme?