### PR TITLE
Mention unstated-props in the related section of the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,4 +516,5 @@ render(
 ## Related
 
 - [unstated-debug](https://github.com/sindresorhus/unstated-debug) - Debug your Unstated containers with ease
+- [unstated-props](https://github.com/mac-r/unstated-props) - Access your Unstated containers from component props
  


### PR DESCRIPTION
Hi @jamiebuilds! 

Great work, it is a lot of fun to use your library! 👍

I just published a HOC for Unstated: 
https://github.com/mac-r/unstated-props 

This is something that we wanted to open-source for a while and now it's finally made public. 
We enjoy using Unstated-Props in our apps. It gives access to your Unstated containers 
from the component props. 

Here is the related tweet:
https://twitter.com/makarochkin/status/1099837703573643264

What do you think of adding a mention to the docs?
Submitting this PR with the related adjustment.

<p align="center">
<img width="800" src='https://cdn.blinkloader.com/express/rF9GczNCw0srKYaWh0NlluCOM/unstated-props.png' alt="unstated-props usage demo" />
</p>