### PR TITLE
Using unstated inside React.StrictMode causes warnings

### DIFF
--- a/src/unstated.js
+++ b/src/unstated.js
@@ -1,10 +1,9 @@
 // @flow
-import React, { type Node } from 'react';
-import createReactContext from 'create-react-context';
+import React, { createContext, type Node } from 'react';
 
 type Listener = () => mixed;
 
-const StateContext = createReactContext(null);
+const StateContext = createContext(null);
 
 export class Container<State: {}> {
   state: State;


### PR DESCRIPTION
React will print these warnings when you use unstated inside strict mode.

![Screenshot from 2019-09-12 21-21-05](https://user-images.githubusercontent.com/2660313/64831355-58efb200-d5a3-11e9-9d79-8654983f7f55.png)

 Removing the `createReactContext()` polyfill seems to fix the issue.